### PR TITLE
refactor: 接入 avodex-backend /service 前缀（next.config rewrite）

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -87,12 +87,17 @@ const nextConfig = {
   async rewrites() {
     // const sourceAry = ["uaapi", "sapi", "fapi", "dapi", "exapi/app", "exapi/lever", "exapi/redemption", "exapi/message", "exapi"];
     const host = process.env.NEXT_PUBLIC_protocol + "//" + process.env.NEXT_PUBLIC_host;
-    return proxyApi.map((path) => {
+    const list = proxyApi.map((path) => {
       return {
         source: `/${path}/:slug*`,
         destination: `${host}/${path}/:slug*`,
       };
     });
+    list.push({
+      source: `/service/:slug*`,
+      destination: `${host}/service/:slug*`,
+    });
+    return list;
   },
   async redirects() {
     const defaultMarket = process.env.NEXT_PUBLIC_DEFAULT_MARKET || "hive_usdt";


### PR DESCRIPTION
## Summary
- next.config.js 新增 `/service/:slug*` rewrite，透传到 avodex-backend
- 老接口路径（uaapi / sapi / dapi / fapi / exapi 等）保持原路径不变
- 对齐 API_FRONTEND.md v2 后端规范

## Test plan
- [ ] 本地启动 dev server，验证 `/service/*` 请求被正确代理到 avodex-backend
- [ ] 老接口（uaapi/sapi/dapi/fapi/exapi）请求路径保持原样，不被 /service 拦截
- [ ] AzAxios 拦截器对 envelope 响应自动剥壳，业务代码拿到的是 data 字段

🤖 Generated with [Claude Code](https://claude.com/claude-code)