### PR TITLE
chore(kline): TradingView exchange 简称 AZ → AVO

### DIFF
--- a/src/components/pages/trade/_cmpt/kline/tradingview/content/index.tsx
+++ b/src/components/pages/trade/_cmpt/kline/tradingview/content/index.tsx
@@ -320,7 +320,7 @@ const Main: React.FC<Props> = ({ option, action, updateTv }) => {
               has_weekly_and_monthly: true,
               session: "24x7", //商品交易时间
               volume_precision: 2, //整数显示此商品的成交量数字的小数位。0表示只显示整数。1表示保留小数位的1个数字字符，等等。
-              exchange: "AZ", //某个交易所的略称
+              exchange: "AVO", //某个交易所的略称
             });
           })
             .then((data) => onSymbolResolvedCallback(data))


### PR DESCRIPTION
## Summary
- TradingView K 线 header 显示的交易所简称从 `AZ` 改为 `AVO`
- 改动位置：`src/components/pages/trade/_cmpt/kline/tradingview/content/index.tsx:323`（resolveSymbol 内联对象）

## 影响评估
- 仅显示用，不影响业务功能
- 代码内无其他位置依赖字符串 `"AZ"` 做匹配/路由
- `searchSymbols` 实现为空回调，未消费 exchange 参数
- 行情/下单链路与 exchange 字段无关
- ⚠️ TradingView 可能把 exchange 拼进图表布局缓存 key，用户已保存的自定义画线/指标可能首次失效一次，之后恢复正常

## Test plan
- [ ] 现货 K 线页面打开 → header 显示 `AVO`
- [ ] 切换 symbol / interval 正常
- [ ] 历史 K 线、实时推送、画线、指标正常
- [ ] H5 端检查一遍

🤖 Generated with [Claude Code](https://claude.com/claude-code)